### PR TITLE
Update smartcropper.rb

### DIFF
--- a/lib/smartcropper.rb
+++ b/lib/smartcropper.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require 'rmagick'
 class SmartCropper
   include Magick
 


### PR DESCRIPTION
Fixing "[DEPRECATION] requiring 'RMagick' is deprecated. Use 'rmagick' instead" warning message
